### PR TITLE
Fix #1: iPad multitasking crashes

### DIFF
--- a/TweakSpring.xm
+++ b/TweakSpring.xm
@@ -461,6 +461,13 @@ CGFloat offset = 0;
 %end
 
 %hook SBMainWorkspace
++(id)_sharedInstanceWithNilCheckPolicy:(long long)arg1 {
+    @try {
+        return %orig(arg1);
+    } @catch (NSException *e) {
+        return nil;
+    }
+}
 -(BOOL)isMedusaEnabled {
 	return YES;
 }


### PR DESCRIPTION
This fix is real quick just ignore the assertion in `+[SBMainWorkspace _sharedInstanceWithNilCheckPolicy:]`